### PR TITLE
Doublejump - Detect for Lava

### DIFF
--- a/Mineplex.sk
+++ b/Mineplex.sk
@@ -1207,7 +1207,7 @@ on flight toggle:
 on jump:
 	player's gamemode is not creative:
 		{DoubleJump%player's uuid%} is not set:
-			block below player is not air or water:
+			block below player is not air or water or lava:
 				set player's flight state to true
 
 on quit:


### PR DESCRIPTION
Make the block below the the player still not be air and water but also make it not lava.