### PR TITLE
/silence message change

### DIFF
--- a/Mineplex.sk
+++ b/Mineplex.sk
@@ -1207,7 +1207,7 @@ on flight toggle:
 on jump:
 	player's gamemode is not creative:
 		{DoubleJump%player's uuid%} is not set:
-			block below player is not air or water:
+			block below player is not air or water or lava:
 				set player's flight state to true
 
 on quit:


### PR DESCRIPTION
For the messages for /silence, 1 of them is not using the correct color and the other has incorrect spelling.
The messages I've changed are the silence and un-silence message. I have checked and confirmed this. Thank you!

New Command:

command /silence:
	permission: mineplex.admin
	permission message: &9Permissions> &7This requires Permission Rank [&9ADMIN&7].
	trigger:
		if {mineplex.chatslow} is set:
			delete {mineplex.chatslow}
			send "&9Chat> &6%player% &7has disabled chat slow." to all players
			set {mineplex.chatsilence} to true
			send "&9Chat> &7The chat has been silenced for &aPermanent&7." to all players
			stop
		if {mineplex.chatsilence} is set:
			delete {mineplex.chatsilence}
			send "&9Chat> &7The chat is no longer silenced." to all players
		else:
			set {mineplex.chatsilence} to true
			send "&9Chat> &7The chat has been silenced for &aPermanent&7." to all players