### PR TITLE
Chat Message Fix

### DIFF
--- a/Mineplex.sk
+++ b/Mineplex.sk
@@ -761,9 +761,8 @@ function mcs(p: player , m: text) :: number:
 							set {_ignore.%loop-player-1%} to true
 					if {_ignore.%loop-player-1%} is not set:
 						if {mineplex.rank.%{_player}%} is not "":
-							replace all "&" with "" in {_m}
 							set {_sanitizedm} to uncolored {_m}
-							mcrjson("%loop-player%", "%{_lvl}%|| %{mineplex.rank.%{_player}%}%||ttp:%{mineplex.hover.%{_player}%}%||&e%{_player}% &f%{_sanitizedm}%")
+							mcrjson("%loop-player%", "%{_lvl}%|| %{mineplex.rank.%{_player}%}%||ttp:%{mineplex.hover.%{_player}%}%||&e%{_player}% &f%{_sanitizedm}%", false)
 						else:
 							send "%{_lvl}% %{mineplex.rank.%{_player}%}%&e%{_player}% &f%{_m}%" to loop-player
 		return -1


### PR DESCRIPTION
# Pull Template

## What does this pull request add?

It fixes the issue so you can use the '&' symbol in chat, without it making the message color-coded.

## Does this fix any issues? If so list the issue number.

1. You can now use '&' in chat if you have a rank
2. You can no-longer use color codes in the chat with '&'.

### __*FOR DEVELOPERS*__:

3. Uses the function 'mcrjson''s third option to remove any color that the user enters in chat.

## Have you tested the code subject in this pull?

Yes, I have tested it and it *only* blocks any color codes the user enters. It still keeps the rank's color, hover rank's color and level color.

#### Thanks for helping out, Wheezy!
