### PR TITLE
Permission Fix with /ma

### DIFF
--- a/Mineplex.sk
+++ b/Mineplex.sk
@@ -2840,20 +2840,17 @@ command /ma [<player>] [<text>]:
 			set {_display2} to "&fPlayer %arg-1%"
 		else:
 			set {_display2} to "%{mineplex.displaya.%arg-1%}% %arg-1%"
-		if player has permission "mineplex.trainee":
-			if argument 1 and argument 2 is set:
-				if arg-1 does not have permission "mineplex.trainee":
-					send "&d<- %{_display}% &d%arg-2%" to arg-1
-					play "NOTE_PLING" to arg-1 at volume 0.5
-				set {mineplex.lasta.%player%} to arg-1
-				loop all players:
-					if loop-player has permission "mineplex.trainee":
-						send "%{_display}% &d-> %{_display2}% &d%arg-2%" to loop-player
-						play "NOTE_PLING" to loop-player at volume 0.5
+		if argument 1 and argument 2 is set:
+			if arg-1 does not have permission "mineplex.trainee":
+				send "&d<- %{_display}% &d%arg-2%" to arg-1
+				play "NOTE_PLING" to arg-1 at volume 0.5
+			set {mineplex.lasta.%player%} to arg-1
+			loop all players:
+				if loop-player has permission "mineplex.trainee":
+					send "%{_display}% &d-> %{_display2}% &d%arg-2%" to loop-player
+					play "NOTE_PLING" to loop-player at volume 0.5
 			else:
 				send "&9Message> &cErr...something went wrong?"
-		else:
-			send "&9Permissions> &7This requires Permission Rank [&9TRAINEE&7]."
 
 command /ra [<text>]:
 	permission: mineplex.trainee

--- a/Mineplex.sk
+++ b/Mineplex.sk
@@ -2849,8 +2849,8 @@ command /ma [<player>] [<text>]:
 				if loop-player has permission "mineplex.trainee":
 					send "%{_display}% &d-> %{_display2}% &d%arg-2%" to loop-player
 					play "NOTE_PLING" to loop-player at volume 0.5
-			else:
-				send "&9Message> &cErr...something went wrong?"
+		else:
+			send "&9Message> &cErr...something went wrong?"
 
 command /ra [<text>]:
 	permission: mineplex.trainee

--- a/Mineplex.sk
+++ b/Mineplex.sk
@@ -2824,6 +2824,8 @@ command /a [<text>]:
 					play "NOTE_PLING" to loop-player at volume 0.5
 
 command /ma [<player>] [<text>]:
+	permission: mineplex.trainee
+	permission message: &9Permissions> &7This requires Permission Rank [&9TRAINEE&7].
 	trigger:
 		if {mineplex.disguise.%player%} is set:
 			send "&9Admin> &7Disguised users cannot use /a while disguised!"


### PR DESCRIPTION
In the real Mineplex Core, /ma is restricted to Trainees only.

It's been tested and works fine.

# Pull Template

## What does this pull request add?

Fixes permissions

## Does this fix any issues? If so list the issue number.
No
## Have you tested the code subject in this pull?

Yes
#### Thanks for helping out, Wheezy!

Thanks
Techno